### PR TITLE
Include missing files in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include __version__.py


### PR DESCRIPTION
Include missing files in sdist for #5

Tested with

```
++ mktemp -d
+ D=/tmp/tmp.XOQsAxFJzJ
+ trap 'rm -rf /tmp/tmp.XOQsAxFJzJ' EXIT
+ python -m venv /tmp/tmp.XOQsAxFJzJ
+ python setup.py sdist -d /tmp/tmp.XOQsAxFJzJ
running sdist
running egg_info
writing py_asl.egg-info/PKG-INFO
writing dependency_links to py_asl.egg-info/dependency_links.txt
writing top-level names to py_asl.egg-info/top_level.txt
reading manifest file 'py_asl.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'py_asl.egg-info/SOURCES.txt'
running check
warning: Check: missing meta-data: if 'author' supplied, 'author_email' must be supplied too

creating py_asl-0.1.4
creating py_asl-0.1.4/py_asl.egg-info
copying files to py_asl-0.1.4...
copying MANIFEST.in -> py_asl-0.1.4
copying README.md -> py_asl-0.1.4
copying __version__.py -> py_asl-0.1.4
copying py_asl.py -> py_asl-0.1.4
copying setup.py -> py_asl-0.1.4
copying py_asl.egg-info/PKG-INFO -> py_asl-0.1.4/py_asl.egg-info
copying py_asl.egg-info/SOURCES.txt -> py_asl-0.1.4/py_asl.egg-info
copying py_asl.egg-info/dependency_links.txt -> py_asl-0.1.4/py_asl.egg-info
copying py_asl.egg-info/top_level.txt -> py_asl-0.1.4/py_asl.egg-info
Writing py_asl-0.1.4/setup.cfg
Creating tar archive
removing 'py_asl-0.1.4' (and everything under it)
+ cd /
+ /tmp/tmp.XOQsAxFJzJ/bin/pip install /tmp/tmp.XOQsAxFJzJ/py_asl-0.1.4.tar.gz
Processing /tmp/tmp.XOQsAxFJzJ/py_asl-0.1.4.tar.gz
Installing collected packages: py-asl
  Running setup.py install for py-asl: started
    Running setup.py install for py-asl: finished with status 'done'
Successfully installed py-asl-0.1.4
WARNING: You are using pip version 19.2.3, however version 20.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
+ echo Success
Success
++ rm -rf /tmp/tmp.XOQsAxFJzJ
```
